### PR TITLE
Implement fullscreen api in project page images

### DIFF
--- a/src/_includes/project-content.liquid
+++ b/src/_includes/project-content.liquid
@@ -27,7 +27,8 @@
             src='{{ image.src | img }}'
             alt='{{ imgAlt }}'
             width='{{ image.width | default: '' }}'
-            height='{{ image.height | default: '' }}'>
+            height='{{ image.height | default: '' }}'
+            class='no-interaction'>
         </li>
       {% endfor %}
 

--- a/src/projects.liquid
+++ b/src/projects.liquid
@@ -23,4 +23,15 @@ permalink: '/projects/{{ project.name | slug }}/'
   {% include footer %}
 </body>
 
+<script>
+  document.querySelectorAll('.project-content__images li')
+    .forEach(function (li) {
+      li.children[0].classList.remove('no-interaction')
+
+      li.addEventListener('click', function() {
+        li.requestFullscreen({ navigationUI: 'show' })
+      })
+    })
+</script>
+
 </html>

--- a/src/styles/sections/project-content.scss
+++ b/src/styles/sections/project-content.scss
@@ -72,6 +72,23 @@
         }
       }
 
+      &:fullscreen {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        img {
+          width: 90%;
+          object-fit: contain;
+
+          &:hover,
+          &:active,
+          &:focus {
+            outline: none;
+          }
+        }
+      }
+
       * {
         width: 100%;
         height: 100%;
@@ -79,9 +96,9 @@
         border: 0.1rem solid rgba(0, 0, 0, 0.1);
         object-fit: cover;
 
-        &:hover,
-        &:active,
-        &:focus {
+        &:not(.no-interaction):hover,
+        &:not(.no-interaction):active,
+        &:not(.no-interaction):focus {
           outline: solid 0.4rem var(--color-text-dark);
         }
       }


### PR DESCRIPTION
## Motivation

In order to add some interaction in project pages, I've decided to implement the [full screen api](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API) into the images from project pages. So now when users click them they enter in full screen mode.

## Changelog

- `src`:
  - `_includes`:
    - `project-content`:
      - Add class `no-interaction` to images
  - `styles`:
    - `sections`:
      - `project-content`:
        - Add specific styling for fullscreen elementws
        - Disable images interaction states until fullscreen code is executed
  - `projects`:
    - Add script that add fullscreen functionality to images from page
