### PR TITLE
Fix iframe video layout in browsers without aspect-ratio support

### DIFF
--- a/src/styles/components/project-content.scss
+++ b/src/styles/components/project-content.scss
@@ -69,6 +69,17 @@
 
       iframe {
         min-height: 30rem;
+        aspect-ratio: 16 / 9;
+
+        @supports not (aspect-ratio: 1 / 1) {
+          width: 100%;
+          height: auto;
+          min-height: 30vh;
+
+          @media (min-width: 720px) {
+            min-height: 70vh;
+          }
+        }
       }
 
       > * {


### PR DESCRIPTION
## Motivation

In projects utilizing a youtube video (like the 3rd default one) had the layout completely broken in browsers without `aspect-ratio` support, so a fallback is necessary.

## Changelog

- **src:**
  - **styles:** 
    - `components`:
      - `project-content`:
        - Improve `iframe` `aspect-ratio` fallback layout
