### PR TITLE
Remove portfolio styles section

### DIFF
--- a/src/data/portfolio.json
+++ b/src/data/portfolio.json
@@ -11,9 +11,6 @@
     "background-light": "#FFFFFF",
     "background-dark": "#1A2A3A"
   },
-  "styles": {
-    "project-preview-aspect-ratio": "1"
-  },
   "i18n": {
     "langs": ["en-US", "pt-BR", "es-MX"],
     "default": "en-US"

--- a/src/styles/components/project-preview.scss
+++ b/src/styles/components/project-preview.scss
@@ -5,7 +5,13 @@
   overflow: hidden;
   background-color: #000;
   text-align: center;
-  aspect-ratio: var(--project-preview-aspect-ratio);
+  aspect-ratio: 1;
+
+  @supports not (aspect-ratio: 1 / 1) {
+    > * {
+      height: var(--project-min-width);
+    }
+  }
 
   &:hover,
   &:active,

--- a/src/styles/components/projects-area.scss
+++ b/src/styles/components/projects-area.scss
@@ -6,12 +6,6 @@
   justify-items: stretch;
   gap: 0.8rem;
 
-  @supports not (aspect-ratio: 1 / 1) {
-    > * {
-      height: var(--project-min-width);
-    }
-  }
-
   @media (min-width: 720px) {
     padding: 1.6rem var(--desktop-horizontal-content-padding);
     gap: 1.6rem;

--- a/src/templates/_includes/components/head.liquid
+++ b/src/templates/_includes/components/head.liquid
@@ -19,7 +19,6 @@
       --color-text-dark: {{ portfolio.colors.text-dark | default: '#333333' }};
       --color-background-light: {{ portfolio.colors.background-light | default: '#FFFFFF' }};
       --color-background-dark: {{ portfolio.colors.background-dark | default: '#1A2A3A' }};
-      --project-preview-aspect-ratio: {{ portfolio.styles.project-preview-aspect-ratio | default: 1 }}
     }
   </style>
 </head>


### PR DESCRIPTION
## Motivation

After reviewing the project, the `styles` section of `portfolio.json` seemed very unnecessary, so I've decided to remove it until there are more properties making it necessary.

## Changelog

- **src:**
  - **data:**
    - `portfolio.json`:
      - Remove `styles` section
  - **styles:** 
    - `components`:
      - `project-preview.scss`:
        - Remove use of css variable `--project-preview-aspect-ratio`
        - Add fallback to `aspect-ratio` property
      - `projects-area.scss`:
        - Move fallback to `aspect-ratio` property to `project-preview.scss`
  - **templates:**
    - `_includes`:
      - `components`:
        - `head.liquid`:
          - Remove declaration of css variable `--project-preview-aspect-ratio`