### PR TITLE
Fix portfolio json optional properties

### DIFF
--- a/src/templates/_includes/components/area-title-default.liquid
+++ b/src/templates/_includes/components/area-title-default.liquid
@@ -7,5 +7,7 @@
     {% endif %}
   </h1>
 
-  <p class='area-title__description'>{{ portfolioDescription }}</p>
+  {% if portfolioDescription %}
+    <p class='area-title__description'>{{ portfolioDescription }}</p>
+  {% endif %}
 </div>

--- a/src/templates/_includes/components/head.liquid
+++ b/src/templates/_includes/components/head.liquid
@@ -1,7 +1,9 @@
 <head>
   <meta charset='utf-8'>
   <meta name='viewport' content='width=device-width, initial-scale=1.0'>
-  <meta name='description' content='{{ portfolioDescription }}'>
+  {% if portfolioDescription %}
+    <meta name='description' content='{{ portfolioDescription }}'>
+  {% endif %}
   <meta name='theme-color' content='{{ portfolio.colors.primary }}'>
   <title>{{ portfolioName }} - {{ title | default: 'Home' }}</title>
   <link rel='icon' href='{{ 'favicon/favicon.ico' | asset }}' />

--- a/src/utils/path.js
+++ b/src/utils/path.js
@@ -1,6 +1,6 @@
 const portfolio = require('../data/portfolio.json')
 
-const getRootPath = () => process.argv.includes('--serve') ? '' : portfolio.root
+const getRootPath = () => process.argv.includes('--serve') || !portfolio.root ? '' : portfolio.root
 
 const getRelativePath = (path, lang) => {
   if (!lang || !portfolio.i18n || lang === portfolio.i18n.default) {


### PR DESCRIPTION
## Motivation

After a few tests, it was noticed that the `portfolio.json` properties `root` and `description` were not optional, so I fixed this.

## Changelog

- **src:**
  - **templates:**
    - `_includes`:
      - `components`:
        - `area-title-default.liquid`:
          - Make description only render if there is a description
        - `head.liquid`:
          - Make description only render if there is a description
  - **utils:**
    - `path.js`:
      - Add another condition to function `getRootPath`, only returning `portfolio.json` `root` property when it is valid
  